### PR TITLE
Update: Game UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,4 @@ For installation on Windows an installer will be included in all releases starti
 ### Map Editor
 At any stage hold down h to view the available contols.
 ### Game
-There are two players. Swap between them with arroykey up/down.
-Every player currently has 3 infantry units, 1 cavalry unit and 1 monster in that order. Switch between the units with arrowkey left/right.
-At the beginning none of the units are placed on the map. They will be placed when they receive their first order.
-Orders are created by clicking one the map twice to specify first the position and then the direction they will be looking in (as the line between first and second click). Orders are handled in a queue. Just clicking normally will replace all orders in the queue. Holding l-Shift  while clicking will instead append the new order to the queue. Pressing enter will send the orders to the currently selected unit and replace their order queue. Holding l-Shifr while pressing enter will instead append all orders from the queue to their order queue.
-Pressing p will toggle between two different movement modes applied to orders that are created while a mode is active. The first is form-up: Units will wait before going to the next order in their queue until at least 90% pf their soldiers have completed their current order. The second is passing-through: Soldiers will immediately go to the next order when they complete a current one.
+The controls being shown on screen can be toggled by pressing h.

--- a/include/base.h
+++ b/include/base.h
@@ -1,7 +1,7 @@
 #ifndef BASE
 #define BASE
 
-#include <linkedlists.h>
+
 #include <events.h>
 #include <units.h>
 #include <debug.h>
@@ -24,10 +24,11 @@ class Listener;
 
 class EventManager {
 	public:
-		std::list<int> noPrint = {GENERIC_EVENT, TICK_EVENT, SDL_EVENT};
+		std::list<int> noPrint = {GENERIC_EVENT, TICK_EVENT, SDL_EVENT, CHANGE_TEXTBOX_EVENT};
 		std::list<Listener*> listeners;
 		int fps = 30;
 		double dt = 1./30.;
+		virtual void _polymorphism(){};	//necessary to make the class polymorphic
 		
 		EventManager() {};
 		EventManager(int fps){
@@ -65,9 +66,23 @@ void EventManager::Post(Event* ev) {
 	if(std::find(noPrint.begin(), noPrint.end(), ev->type)==noPrint.end()) {
 		std::cout << " - posted " << ev->name << "\n";
 	}
-	for (std::list<Listener*>::iterator it = listeners.begin(); it != listeners.end(); it++) {
-			(*it)->Notify(ev);
+	for(auto listener : listeners) {
+		listener->Notify(ev);
 	}
 }
+
+class KeyboardAndMouseController;
+class Model;
+
+class GameEventManager : public EventManager {
+public:
+	KeyboardAndMouseController* ctrl;
+	Model* model;
+
+	GameEventManager(int fps) : EventManager(fps){
+		ctrl = NULL;
+		model = NULL;
+	}
+};
 
 #endif

--- a/include/debug.h
+++ b/include/debug.h
@@ -4,10 +4,14 @@
 #include <iostream>
 #include <string>
 
-bool _showDebugMessages = false;
+namespace ddebug {
+	bool _showDebugMessages = false;
+	bool _showDebugGraphics = false;
+}
+
 
 void debug(std::string text) {
-	if(_showDebugMessages) {
+	if(ddebug::_showDebugMessages) {
 		std::cout << "[DEBUG:] " << text << "\n";
 	}
 }

--- a/include/events.h
+++ b/include/events.h
@@ -1,7 +1,6 @@
 #ifndef EVENTS
 #define EVENTS
 
-#include <linkedlists.h>
 
 #include <list>
 #include <string>
@@ -17,12 +16,20 @@ enum EVENT_IDS {
 	QUIT_EVENT,
 	CLICK_EVENT,
 	GIVE_ORDERS_REQUEST,
+	REMEMBER_ORDERS,
 	APPEND_ORDERS_REQUEST,
 	UNIT_MOVE_REQUEST,
 	UNIT_PLACE_REQUEST,
 	KILL_EVENT,
 	UNIT_SELECT_EVENT,
-	PLAYER_SELECT_EVENT
+	UNIT_ADD_EVENT,
+	UNIT_DELETE_EVENT,
+	PLAYER_SELECT_EVENT,
+	PLAYER_ADD_EVENT,
+	PLAYER_DELETE_EVENT,
+	CTRL_STATE_EVENT,
+	INPUT_RECEIVED_EVENT,
+	CHANGE_TEXTBOX_EVENT
 };
 
 class Event {
@@ -99,6 +106,17 @@ class GiveOrdersRequest : public Event {
 		}
 };
 
+class RememberOrders : public Event {
+	public:
+		std::vector<Order*> orders;
+
+		RememberOrders(std::vector<Order*> orders) : Event() {
+			name = "RememberOrders";
+			type = REMEMBER_ORDERS;
+			this->orders = orders;
+		}
+};
+
 class AppendOrdersRequest : public Event {
 	public:
 		Unit* unit;
@@ -168,6 +186,25 @@ class UnitSelectEvent : public Event {
 		}
 };
 
+class UnitAddEvent : public Event {
+	public:
+		int unitType;
+
+		UnitAddEvent(int type) : Event() {
+			name = "UnitAddEvent";
+			this->type = UNIT_ADD_EVENT;
+			unitType = type;
+		}
+};
+
+class UnitDeleteEvent : public Event {
+	public:
+		UnitDeleteEvent() : Event() {
+			name = "UnitDeleteEvent";
+			type = UNIT_DELETE_EVENT;
+		}
+};
+
 class PlayerSelectEvent : public Event {
 	public:
 		int playerID;
@@ -177,6 +214,52 @@ class PlayerSelectEvent : public Event {
 			type = PLAYER_SELECT_EVENT;
 			playerID = pID;
 		}
+};
+
+class PlayerAddEvent : public Event {
+	public:
+		PlayerAddEvent() : Event() {
+			name = "PlayerAddEvent";
+			type = PLAYER_ADD_EVENT;
+		}
+};
+
+class PlayerDeleteEvent : public Event {
+	public:
+		PlayerDeleteEvent() : Event() {
+			name = "PlayerDeleteEvent";
+			type = PLAYER_DELETE_EVENT;
+		}
+};
+
+class CtrlStateEvent : public Event {
+public:
+	int state;
+
+	CtrlStateEvent(int state) : Event() {
+		name = "CtrlStateEvent";
+		type = CTRL_STATE_EVENT;
+		this->state = state;
+	}
+};
+
+class InputReceivedEvent : public Event {
+public:
+	InputReceivedEvent() : Event() {
+		name = "InputReceivedEvent";
+		type = INPUT_RECEIVED_EVENT;
+	}
+};
+
+class ChangeTextboxEvent : public Event {
+public:
+	std::string text;
+
+	ChangeTextboxEvent(std::string text) : Event() {
+		name = "ChangeTextboxEvent";
+		type = CHANGE_TEXTBOX_EVENT;
+		this->text = text;
+	}
 };
 
 #endif

--- a/include/map.h
+++ b/include/map.h
@@ -42,9 +42,9 @@ public:
 
 class gridpiece{
 	public:
-		LinkedList<Soldier*> soldiers;
+		std::vector<Soldier*> soldiers;
 		std::vector<MapObject*> mapObjects;
-		LinkedList<gridpiece*> neighbours;
+		std::vector<gridpiece*> neighbours;
 		Rrectangle* rec;
 };
 
@@ -77,14 +77,14 @@ class Map {
 			}
 			for(int i = 0; i < nrows - 1; i++) {
 				for(int j = 0; j < ncols - 1; j++) {
-					tiles.at(i).at(j)->neighbours.Append(new Node<gridpiece*>(tiles.at(i+1).at(j)));
-					tiles.at(i).at(j)->neighbours.Append(new Node<gridpiece*>(tiles.at(i).at(j+1)));
-					tiles.at(i).at(j)->neighbours.Append(new Node<gridpiece*>(tiles.at(i+1).at(j+1)));
+					tiles.at(i).at(j)->neighbours.push_back(tiles.at(i+1).at(j));
+					tiles.at(i).at(j)->neighbours.push_back(tiles.at(i).at(j+1));
+					tiles.at(i).at(j)->neighbours.push_back(tiles.at(i+1).at(j+1));
 					if(i == 0) {
-						tiles.at(nrows-1).at(j)->neighbours.Append(new Node<gridpiece*>(tiles.at(nrows-1).at(j+1)));
+						tiles.at(nrows-1).at(j)->neighbours.push_back(tiles.at(nrows-1).at(j+1));
 					}
 				}
-				tiles.at(i).at(ncols-1)->neighbours.Append(new Node<gridpiece*>(tiles.at(i+1).at(ncols-1)));
+				tiles.at(i).at(ncols-1)->neighbours.push_back(tiles.at(i+1).at(ncols-1));
 			}
 			//creating map borders, but not adding them to objects yet
 			double hw = 0.5*width;
@@ -117,13 +117,13 @@ class Map {
 		void Cleangrid() {
 			for(int i = 0; i < nrows; i++) {
 				for(int j = 0; j < ncols; j++) {
-					tiles.at(i).at(j)->soldiers.Empty();
+					tiles.at(i).at(j)->soldiers.clear();
 				}
 			}
 		}
 		
 		void Assign(Soldier* soldier, int i, int j) {
-			tiles.at(i).at(j)->soldiers.Append(new Node<Soldier*>(soldier));
+			tiles.at(i).at(j)->soldiers.push_back(soldier);
 		}
 
 		void AddMapObject(MapObject* obj) {
@@ -336,7 +336,6 @@ void SoldierRectangleCollision(Soldier* soldier, Rrectangle* rec) {
 				}
 			}
 		}
-	// missing case for collision with corners
 	}
 	//knockVel << 0., 0.;
 	soldier->knockVel += knockVel;

--- a/include/player.h
+++ b/include/player.h
@@ -2,10 +2,11 @@
 #define PLAYER
 
 #include <base.h>
+#include <vector>
 
 class Player {
 	public:
-		LinkedList<Unit*> units;
+		std::vector<Unit*> units;
 		
 		Player() {};
 };


### PR DESCRIPTION
This update adds a UI similar to that of the map editor to the main game.

- The main game can now load any map from a filename via textinput.
- Players and units can be added and removed from the game at runtime.
- Units can be selected by clicking.
- Changed KeyboardAndMouseController to be based on a state-variable like map_editor.
- Slightly revised the controll scheme. All controls are now viewable in-game.
- Added option to debug to toggle certain elements of the view object.
- Added rendered text to view object.
- Added visualization of orders that are created but unsent.
- Added visualization of unplaced unit at the mouse cursor when giving orders.- New Events: RememberOrders (Sends currently orders of next selected unit to controller when selecting a different unit.), UnitAddEvent, UnitDeleteEvent, PlayerAddEvent, PlayerDeleteEvent, CtrlStateEvent, InputReceivedEvent, ChangeTextboxEvent
- Added function to get rectangle from unit and orders that have not yet been assigned.
- New subclass GameEventManager of EventManager that holds references to Controller and Model. This allows Listeners to read certain public values without all Listeneres being notified of unnecessary events.
- Phased out all remaining linked lists and replaced them with vectors or deques.